### PR TITLE
Homework4

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,0 +1,27 @@
+Kubernetes
+
+Kubernetes установлен локально через  **minikube**
+
+### Используемые образы:
+
+    annasmelova/online_inference:v1
+    annasmelova/online_inference:v2
+
+Второй образ с задержкой 25 секунд при старте и с прерыванием работы через 120 секунд.
+
+### Проверка, что кластер поднялся:
+
+    kubectl cluster-info
+  
+### Деплой приложений в кластер:
+
+    kubectl apply -f kubernetes/online-inference-pod.yaml
+    kubectl apply -f kubernetes/online-inference-pod-resources.yaml
+    kubectl apply -f kubernetes/online-inference-pod-probes.yaml
+    kubectl apply -f kubernetes/online-inference-replicaset.yaml
+    kubectl apply -f kubernetes/online-inference-deployment-blue-green.yaml
+    kubectl apply -f kubernetes/online-inference-deployment-rolling-update.yaml
+  
+### Проверка, что все поднялось:
+
+    kubectl get pods

--- a/kubernetes/app.py
+++ b/kubernetes/app.py
@@ -1,0 +1,91 @@
+import logging
+import os
+import sys
+import time
+from typing import List
+
+import numpy as np
+import uvicorn
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from src.get_data_utils import get_model, read_config_params
+
+
+logger = logging.getLogger(__name__)
+handler = logging.StreamHandler(sys.stdout)
+logger.setLevel(logging.INFO)
+logger.addHandler(handler)
+
+CONFIG_PATH = 's3_config.yaml'
+
+s3_bucket = None
+model = None
+
+
+class DataModel(BaseModel):
+    data: List[List[float]]
+
+
+class PredictResponse(BaseModel):
+    heart_disease: int
+
+
+app = FastAPI()
+
+start_time = time.time()
+
+
+@app.get("/")
+def main():
+    return "Hello, WORLD! It is entry point of our predictor."
+
+
+@app.on_event("startup")
+def get_config():
+    time.sleep(25)
+    config_params = read_config_params(CONFIG_PATH)
+    os.environ['S3_BUCKET'] = config_params.s3_bucket
+    os.environ['PATH_TO_MODEL'] = config_params.path_to_model
+
+
+@app.on_event("startup")
+def get_s3():
+    global s3_bucket
+    s3_bucket = os.getenv("S3_BUCKET")
+    if s3_bucket is None:
+        err = f"S3_BUCKET {s3_bucket} is None"
+        logger.error(err)
+        raise RuntimeError(err)
+
+
+@app.on_event("startup")
+def load_model():
+    global model
+    path_to_model = os.getenv("PATH_TO_MODEL")
+
+    if path_to_model is None:
+        err = f"PATH_TO_MODEL {path_to_model} is None"
+        logger.error(err)
+        raise RuntimeError(err)
+
+    model = get_model(s3_bucket, path_to_model)
+
+
+@app.get("/health")
+def health() -> bool:
+    global start_time
+    if time.time() - start_time > 120:
+        raise RuntimeError('Application runtime limit exceeded')
+    return not (model is None) and \
+           not (s3_bucket is None)
+
+
+@app.post("/predict/", response_model=List[PredictResponse])
+def predict(request: DataModel) -> List[PredictResponse]:
+    predictions = model.predict(np.array(request.data))
+    return [PredictResponse(heart_disease=p) for p in predictions]
+
+
+if __name__ == "__main__":
+    uvicorn.run("app:app", host="0.0.0.0", port=os.getenv("PORT", 8000))

--- a/kubernetes/online-inference-deployment-blue-green.yaml
+++ b/kubernetes/online-inference-deployment-blue-green.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: online-inference-blue-green
+  labels:
+    app: online-inference
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 3
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: online-inference
+  template:
+    metadata:
+      name: online-inference-blue-green
+      labels:
+        app: online-inference
+    spec:
+      containers:
+        - image: annasmelova/online_inference:v1
+          name: online-inference
+          ports:
+            - containerPort: 8000

--- a/kubernetes/online-inference-deployment-rolling-update.yaml
+++ b/kubernetes/online-inference-deployment-rolling-update.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: online-inference-rolling-update
+  labels:
+    app: online-inference
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: online-inference
+  template:
+    metadata:
+      name: online-inference-rolling-update
+      labels:
+        app: online-inference
+    spec:
+      containers:
+        - image: annasmelova/online_inference:v1
+          name: online-inference
+          ports:
+            - containerPort: 8000

--- a/kubernetes/online-inference-pod-probes.yaml
+++ b/kubernetes/online-inference-pod-probes.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: online-inference-probes
+  labels:
+    app: online-inference
+spec:
+  containers:
+    - image: annasmelova/online_inference:v2
+      name: online-inference
+      ports:
+        - containerPort: 8000
+      readinessProbe:
+        httpGet:
+          path: /health
+          port: 8000
+        initialDelaySeconds: 30
+        periodSeconds: 5
+      livenessProbe:
+            httpGet:
+                path: /health
+                port: 8000            
+            initialDelaySeconds: 40
+            periodSeconds: 10

--- a/kubernetes/online-inference-pod-resources.yaml
+++ b/kubernetes/online-inference-pod-resources.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: online-inference-resourses
+  labels:
+    app: online-inference
+spec:
+  containers:
+    - image: annasmelova/online_inference:v1
+      name: online-inference
+      ports:
+        - containerPort: 8000
+      resources:
+        requests:
+          memory: "1Gi"
+          cpu: "250m"
+        limits:
+          memory: "2Gi"
+          cpu: "500m"

--- a/kubernetes/online-inference-pod.yaml
+++ b/kubernetes/online-inference-pod.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: online-inference
+  labels:
+    app: online-inference
+spec:
+  containers:
+    - image: annasmelova/online_inference:v1
+      name: online-inference
+      ports:
+        - containerPort: 8000

--- a/kubernetes/online-inference-replicaset.yaml
+++ b/kubernetes/online-inference-replicaset.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: online-inference-replicaset
+  labels:
+    app: online-inference
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: online-inference
+  template:
+    metadata:
+      name: online-inference-replicaset
+      labels:
+        app: online-inference
+    spec:
+      containers:
+        - image: annasmelova/online_inference:v1
+          name: online-inference
+          ports:
+            - containerPort: 8000


### PR DESCRIPTION
**Критерии:**

- [x] Установите kubectl

- [x] Разверните Kubernetes (5 баллов)
Кластер развернут локально, используя **minikube**:
<img width="783" alt="minikube" src="https://user-images.githubusercontent.com/16071771/175816046-d09e6ecc-f368-4199-b43b-6a908cf3a24c.png">

Убедитесь, что кластер поднялся:
<img width="754" alt="cluster-info" src="https://user-images.githubusercontent.com/16071771/175816072-0e3f48e6-4d6e-442c-8ec2-b4a23bb52213.png">

- [x] Напишите простой [Pod manifest](https://kubernetes.io/docs/concepts/workloads/pods/) для вашего приложения, назовите его online-inference-pod.yaml (4 балла)
<img width="724" alt="online-inference-pod" src="https://user-images.githubusercontent.com/16071771/175816115-73128981-127e-4b70-9020-a2050d6b32ba.png">

- [x] Пропишите Requests / Limits и напишите, зачем это нужно в описании PR. Закоммитьте файл online-inference-pod-resources.yaml (2 балла)
<img width="793" alt="online-inference-pod-resources" src="https://user-images.githubusercontent.com/16071771/175816151-fbb1d114-9430-4224-bb10-8819e860f3d6.png">
Requests - гарантируемые ресурсы, Limits - ограничение ресурсов сверху. Limits лучше ставить всегда выше, чем Requests, чтобы приложение не падало в момент пиковой нагрузки.


- [x] Модифицируйте свое приложение так, чтобы оно стартовало не сразу (с задержкой 20-30 секунд) и падало спустя минуты работы. Добавьте Liveness и Readiness пробы и посмотрите, что будет происходить. Напишите в описании -- чего вы этим добились. Закоммитьте отдельный манифест online-inference-pod-probes.yaml (и изменение кода приложения). Опубликуйте ваше приложение (из ДЗ 2) с тэгом v2 (3 балла)
<img width="768" alt="online-inference-pod-probes" src="https://user-images.githubusercontent.com/16071771/175816174-d91c86a7-9ab9-4671-8478-4a0bb58d1d52.png">
Образ annasmelova/online_inference:v2 с задержкой 25 секунд при старте и с прерыванием работы через 120 секунд. Liveness отвечает за рестарт контейнера после прерывания, Readiness ждет готовности приложения.
Изменение кода приложения закоммитила одним файлом app.py, чтобы не добавлять весь проект online_inference.

- [x] Создайте [ReplicaSet](https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/), сделайте 3 реплики вашего приложения. Закоммитьте online-inference-replicaset.yaml (3 балла)
<img width="767" alt="online-inference-replicaset" src="https://user-images.githubusercontent.com/16071771/175816341-8a84f8c3-dd1c-42e9-9aa3-7e7ab9243a99.png">
a) Если уменьшить число реплик, то останется только указанное число реплик с начальным докер-образом
б) Если увеличить число реплик, то добавится недостающее количество реплик с новым докер-образом, а старые реплики останутся с начальным докер-образом

- [x] Опишите [Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) для вашего приложения (3 балла) Играя с параметрами деплоя (maxSurge, maxUnavaliable), добейтесь ситуации, когда при деплое новой версии:

a) есть момент времени, когда на кластере существуют как все старые поды, так и все новые (опишите эту ситуацию) (закоммитьте файл online-inference-deployment-blue-green.yaml)

б) одновременно с поднятием новых версий, гасятся старые (закоммитьте файл online-inference-deployment-rolling-update.yaml)

maxSurge - количество подов, которое может быть создано сверх жедаемого количества подов
maxUnavaliable - количество подов, которые могут быть погашены в процессе обновления

Сумма: 20